### PR TITLE
Add pipefail and cleanup var handling as a result

### DIFF
--- a/entrypoints/cmdline.sh
+++ b/entrypoints/cmdline.sh
@@ -105,8 +105,22 @@ cmdline() {
     mkdir -p "${JSON_TMP}"
   fi
 
+  # we always want these env settings to exist in normal circumstances even if just empty
+  declare -gx SNYK_BULK_DEBUG="${SNYK_BULK_DEBUG:='0'}"
+  declare -gx FAIL="${FAIL:="all"}"
+  declare -gx SEVERITY="${SEVERITY:="low"}"
+  declare -gx REMOTE_REPO_URL="${REMOTE_REPO_URL:='0'}"
+  declare -gx POLICY_FILE_PATH="${POLICY_FILE_PATH:='0'}"
+  declare -gx SNYK_MONITOR="${SNYK_MONITOR:='0'}"
+  declare -gx SNYK_TEST="${SNYK_TEST:='0'}"
+
+  if [[ "${SNYK_BULK_DEBUG}" == '1' ]]; then
+    set -euo pipefail
+    set -x
+  fi
+
   # shellcheck disable=SC2034
-  readonly LOG_FILE
+  readonly LOG_FILE FAIL SEVERITY REMOTE_REPO_URL POLICY_FILE_PATH SNYK_MONITOR SNYK_TEST SNYK_BULK_DEBUG
 
   return 0
 }

--- a/entrypoints/util.sh
+++ b/entrypoints/util.sh
@@ -5,7 +5,7 @@
 source "${SOURCEDIR}/cmdline.sh"
 
 set_debug(){
-  if ! [[ -z "${SNYK_BULK_DEBUG}" ]]; then
+  if [[ "${SNYK_BULK_DEBUG}" == '1' ]]; then
     set -x
   fi
 }
@@ -36,10 +36,10 @@ run_snyk() {
 
 snyk_cmd(){
   set_debug
-  if ! [[ -z "${SNYK_BULK_DEBUG}" ]]; then
+  if [[ "${SNYK_BULK_DEBUG}" == '1' ]]; then
     SNYK_DEBUG="--debug"
   else
-    SNYK_DEBUG="--quiet"
+    SNYK_DEBUG=""
     declare -xg CI=1
   fi
   local snyk_action manifest pkg_manager project
@@ -50,25 +50,20 @@ snyk_cmd(){
 
   local severity_level fail_on remote_repo
 
-  if ! [[ -z "${SEVERITY}" ]]; then
-    severity_level="${SEVERITY}"
-  else
-    severity_level="low"
-  fi
-  
-  if ! [[ -z "${FAIL}" ]]; then
-    fail_on="${FAIL}"
-  else
-    fail_on="all"
-  fi
+  severity_level="${SEVERITY}"  
+  fail_on="${FAIL}"
 
-  if ! [[ -z "${REMOTE_REPO_URL}" ]]; then
+
+  if [[ "${REMOTE_REPO_URL}" != '0' ]]; then
     remote_repo="--remote-repo-url=${REMOTE_REPO_URL}"
+  else
+    remote_repo=''
   fi
 
   mkdir -p "${JSON_TMP}/${snyk_action}/pass"
   mkdir -p "${JSON_TMP}/${snyk_action}/fail"
-  
+
+  # shellcheck disable=SC2086
   project_clean="$(echo ${project} | tr '/' '-' | tr ' ' '-' )"
   
   project_json_fail="${JSON_TMP}/${snyk_action}/fail/$(basename "${0}")-${project_clean}.json"


### PR DESCRIPTION
This now sets set -euo pipefail while in debug mode, so snyk-bulk fails fast and early

Since in normal practice this is really a 'best effort' tool, we want to keep scanning every project even if the last project scan bombed out snyk or failed to pass a test, this helps us debug execution while doing so (this will also break when a snyk test breaks the build - have to be super smart about how we call snyk to surprise it's pipefail errors at some point if this causes more debugging issues)

also will fail on unset variables and exit immediately in case of any error

- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
