### PR TITLE
Fix: Find globbing patterns would blow up

### DIFF
--- a/entrypoints/go.sh
+++ b/entrypoints/go.sh
@@ -79,8 +79,10 @@ go::main() {
   local gomodfile
 #  local godepfile
 
+  set -o noglob
   readarray -t gomodfile < <(find "${SNYK_TARGET}" -type f -name "go.mod" $SNYK_IGNORES )
 #  readarray -t godepfile < <(find "${SNYK_TARGET}" -type f -name "Gopkg.lock" $SNYK_IGNORES )
+  set +o noglob
 
   for gomodfile in "${gomodfile[@]}"; do
     snyk_gomod "${gomodfile}"

--- a/entrypoints/maven.sh
+++ b/entrypoints/maven.sh
@@ -52,8 +52,10 @@ maven::main() {
 
   local pomfiles
 
+  set -o noglob
   readarray -t pomfiles < <(find "${SNYK_TARGET}" -type f -name "pom.xml" $SNYK_IGNORES )
-  
+  set +o noglob
+
   for pomfile in "${pomfiles[@]}"; do
     snyk_pomfile "${pomfile}"
   done

--- a/entrypoints/python.sh
+++ b/entrypoints/python.sh
@@ -163,10 +163,12 @@ python::main() {
   local reqfiles
   local setupfiles
 
+  set -o noglob
   readarray -t pipfiles < <(find "${SNYK_TARGET}" -type f -name "Pipfile" $SNYK_IGNORES )
   readarray -t poetryfiles < <(find "${SNYK_TARGET}" -type f -name "pyproject.toml" $SNYK_IGNORES )
   readarray -t reqfiles < <(find "${SNYK_TARGET}" -type f -name "requirements.txt" $SNYK_IGNORES )
   readarray -t setupfiles < <(find "${SNYK_TARGET}" -type f -name "setup.py" $SNYK_IGNORES )
+  set +o noglob
   
   for pipfile in "${pipfiles[@]}"; do
     snyk_pipfile "${pipfile}"


### PR DESCRIPTION
Because of bash shell expansion being on by default, if the folders we
didn't want to include in our find actually existed on the path, it could
cause find command to blowup

This fixes that by wrapping every find statement as:
set -o noglob
FIND command
set +o noglob
