### PR TITLE
Fixes regression of removal of the --quiet flag

### DIFF
--- a/entrypoints/util.sh
+++ b/entrypoints/util.sh
@@ -39,7 +39,7 @@ snyk_cmd(){
   if [[ "${SNYK_BULK_DEBUG}" == 1 ]]; then
     SNYK_DEBUG="--debug"
   else
-    SNYK_DEBUG="--quiet"
+    SNYK_DEBUG=""
   fi
   local snyk_action manifest pkg_manager project
   snyk_action="${1}"


### PR DESCRIPTION
the absence of --debug would force quiet mode which would squash monitor's json output
