### PR TITLE
Adds support for -- flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ json_output/
 .venv//
 .vscode/
 .idea/
+.dccache


### PR DESCRIPTION
snyk bulk will now take a -- flag and pass options (as an array) to snyk
itself. In order to utilize Snyk's -- flag, it will then need to be called
twice (ie, entrypoint.sh -- -- --$compileroption)

- [X] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team
